### PR TITLE
Reusable logo able to switch depending on dark/light theme

### DIFF
--- a/lib/app_bar.dart
+++ b/lib/app_bar.dart
@@ -4,6 +4,7 @@ import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:screensite/main.dart';
 import 'package:screensite/state/theme_state_notifier.dart';
 import 'package:screensite/common.dart';
+import 'package:logo/logo.dart';
 
 class MyAppBar {
   static final List<String> _tabs = [
@@ -20,6 +21,14 @@ class MyAppBar {
           (MediaQuery.of(context).size.width < WIDE_SCREEN_WIDTH)
               ? true
               : false,
+      leadingWidth:
+          (MediaQuery.of(context).size.width < WIDE_SCREEN_WIDTH) ? null : 100,
+      leading: (MediaQuery.of(context).size.width < WIDE_SCREEN_WIDTH)
+          ? null
+          : Padding(
+              padding: EdgeInsets.all(10),
+              child: Logo(),
+            ),
       title: (MediaQuery.of(context).size.width < WIDE_SCREEN_WIDTH)
           ? null
           : Align(
@@ -49,7 +58,7 @@ class MyAppBar {
                     },
                   ))),
       actions: [
-        //ThemeIconButton(),
+        ThemeIconButton(),
         IconButton(
             onPressed: () {
               ref.read(isLoggedIn.notifier).value = false;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -335,8 +335,8 @@ packages:
     dependency: "direct main"
     description:
       path: login
-      ref: logo
-      resolved-ref: "6d8e2e8bb50a1428ec6aadc075fa476d8f3ed8c6"
+      ref: logo-theme
+      resolved-ref: b7d168ef210af05e2929499d442a6f45ede53647
       url: "https://github.com/amlcloud/flutter-lib.git"
     source: git
     version: "0.0.1"
@@ -344,8 +344,8 @@ packages:
     dependency: "direct main"
     description:
       path: logo
-      ref: logo
-      resolved-ref: f661e84c9e8cc61972645e239cf3baaad89460c6
+      ref: logo-theme
+      resolved-ref: b7d168ef210af05e2929499d442a6f45ede53647
       url: "https://github.com/amlcloud/flutter-lib.git"
     source: git
     version: "0.0.1"

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -335,8 +335,8 @@ packages:
     dependency: "direct main"
     description:
       path: login
-      ref: logo-theme
-      resolved-ref: b7d168ef210af05e2929499d442a6f45ede53647
+      ref: HEAD
+      resolved-ref: "9f2e022cbd593a1f1d7893c1b01a811202dd7822"
       url: "https://github.com/amlcloud/flutter-lib.git"
     source: git
     version: "0.0.1"
@@ -344,8 +344,8 @@ packages:
     dependency: "direct main"
     description:
       path: logo
-      ref: logo-theme
-      resolved-ref: b7d168ef210af05e2929499d442a6f45ede53647
+      ref: HEAD
+      resolved-ref: "9f2e022cbd593a1f1d7893c1b01a811202dd7822"
       url: "https://github.com/amlcloud/flutter-lib.git"
     source: git
     version: "0.0.1"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,11 +46,13 @@ dependencies:
     git: 
       url: https://github.com/amlcloud/flutter-lib.git
       path: login
+      ref: logo-theme
   country_picker: ^2.0.16
   logo:
     git:
       url: https://github.com/amlcloud/flutter-lib.git
       path: logo
+      ref: logo-theme
 
 
 dev_dependencies:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -46,13 +46,11 @@ dependencies:
     git: 
       url: https://github.com/amlcloud/flutter-lib.git
       path: login
-      ref: logo-theme
   country_picker: ^2.0.16
   logo:
     git:
       url: https://github.com/amlcloud/flutter-lib.git
       path: logo
-      ref: logo-theme
 
 
 dev_dependencies:


### PR DESCRIPTION
Closes: #21 

Changes:
- Added reusable logo to appbar

Notes:
- When in light theme, the logo in drawer can't really be seen because the background is white (instead of blue on the appbar). I think this can be fixed by either: Having a separate drawer theme, hardcoding drawer to only use the dark theme logo regardless of current theme state, or changing drawer colour in light theme mode. 
