### PR TITLE
Moved 3 links widgets from list_list_item.dart to list_details.dart

### DIFF
--- a/lib/lists/list_details.dart
+++ b/lib/lists/list_details.dart
@@ -5,6 +5,11 @@ import 'package:screensite/lists/list_entitylistview.dart';
 import 'package:screensite/lists/list_indexing.dart';
 import 'package:screensite/state/generic_state_notifier.dart';
 import 'package:screensite/theme.dart';
+import 'package:screensite/providers/firestore.dart';
+import 'package:screensite/controls/doc_field_text_edit.dart';
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:url_launcher/url_launcher.dart';
+import 'package:flutter/gestures.dart';
 
 import 'list_count.dart';
 
@@ -27,6 +32,157 @@ class ListDetails extends ConsumerWidget {
           mainAxisSize: MainAxisSize.max,
           children: [
             Flexible(flex: 1, child: ListInfo(entityId)),
+            Divider(),
+
+            Container(
+                child: ref.watch(docSP('list/' + entityId)).when(
+                    loading: () => Container(),
+                    error: (e, s) => ErrorWidget(e),
+                    data: (entityDoc) => entityDoc.exists == false
+                        ? Center(child: Text('No entity data exists'))
+                        : Container(
+                            child: Column(
+                                mainAxisSize: MainAxisSize.min,
+                                children: <Widget>[
+                                Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    children: <Widget>[
+                                      Container(
+                                          padding: EdgeInsets.all(8.0),
+                                          child: Text.rich(TextSpan(
+                                              style: TextStyle(
+                                                  decoration:
+                                                      TextDecoration.underline),
+                                              //make link underline
+                                              text: "View source page",
+                                              recognizer: TapGestureRecognizer()
+                                                ..onTap = () async {
+                                                  //on tap code here, you can navigate to other page or URL
+                                                  final url = Uri.parse(
+                                                      entityDoc.data()![
+                                                              'domainURL'] ??
+                                                          '#');
+                                                  var urllaunchable =
+                                                      await canLaunchUrl(
+                                                          url); //canLaunch is from url_launcher package
+                                                  if (urllaunchable) {
+                                                    await launchUrl(
+                                                        url); //launch is from url_launcher package to launch URL
+                                                  } else {
+                                                    print(
+                                                        "URL can't be launched.");
+                                                  }
+                                                })))
+                                    ]),
+                                Row(
+                                    mainAxisAlignment: MainAxisAlignment.start,
+                                    children: <Widget>[
+                                      Container(
+                                          padding: EdgeInsets.all(8.0),
+                                          child: Text.rich(TextSpan(
+                                              style: TextStyle(
+                                                  decoration:
+                                                      TextDecoration.underline),
+                                              //make link underline
+                                              text: "View source list",
+                                              recognizer: TapGestureRecognizer()
+                                                ..onTap = () async {
+                                                  //on tap code here, you can navigate to other page or URL
+                                                  final url = Uri.parse(
+                                                      entityDoc.data()![
+                                                              'listURL'] ??
+                                                          '#');
+                                                  var urllaunchable =
+                                                      await canLaunchUrl(
+                                                          url); //canLaunch is from url_launcher package
+                                                  if (urllaunchable) {
+                                                    await launchUrl(
+                                                        url); //launch is from url_launcher package to launch URL
+                                                  } else {
+                                                    print(
+                                                        "URL can't be launched.");
+                                                  }
+                                                })))
+                                    ]),
+                                InkWell(
+                                    child: IconButton(
+                                        icon: const Icon(Icons.edit),
+                                        onPressed: () {
+                                          showDialog(
+                                              context: context,
+                                              builder: (BuildContext context) {
+                                                final _formKey =
+                                                    GlobalKey<FormState>();
+                                                return AlertDialog(
+                                                  scrollable: true,
+                                                  title: Text(
+                                                      'Sanction list entity fields'),
+                                                  content: Padding(
+                                                    padding:
+                                                        const EdgeInsets.all(
+                                                            8.0),
+                                                    child: Form(
+                                                      key: _formKey,
+                                                      child: Column(
+                                                        children: <Widget>[
+                                                          DocFieldTextEdit(
+                                                              FirebaseFirestore
+                                                                  .instance
+                                                                  .doc(
+                                                                      'list/${entityId}'),
+                                                              'name',
+                                                              decoration:
+                                                                  InputDecoration(
+                                                                      hintText:
+                                                                          "Entity Name")),
+                                                          DocFieldTextEdit(
+                                                              FirebaseFirestore
+                                                                  .instance
+                                                                  .doc(
+                                                                      'list/${entityId}'),
+                                                              'address',
+                                                              decoration:
+                                                                  InputDecoration(
+                                                                      hintText:
+                                                                          "Entity address")),
+                                                          DocFieldTextEdit(
+                                                              FirebaseFirestore
+                                                                  .instance
+                                                                  .doc(
+                                                                      'list/${entityId}'),
+                                                              'dataSource',
+                                                              decoration:
+                                                                  InputDecoration(
+                                                                      hintText:
+                                                                          "Data Source")),
+                                                          DocFieldTextEdit(
+                                                              FirebaseFirestore
+                                                                  .instance
+                                                                  .doc(
+                                                                      'list/${entityId}'),
+                                                              'website',
+                                                              decoration:
+                                                                  InputDecoration(
+                                                                      hintText:
+                                                                          "Website")),
+                                                        ],
+                                                      ),
+                                                    ),
+                                                  ),
+                                                  actions: [
+                                                    ElevatedButton(
+                                                      onPressed: () {
+                                                        Navigator.of(context)
+                                                            .pop();
+                                                      },
+                                                      child: const Text('Done'),
+                                                    )
+                                                  ],
+                                                );
+                                              });
+                                        })),
+                              ])))),
+
             Divider(),
             ListIndexing(entityId),
             Divider(),

--- a/lib/lists/list_list_item.dart
+++ b/lib/lists/list_list_item.dart
@@ -6,9 +6,7 @@ import 'package:screensite/lists/lists_page.dart';
 import 'package:screensite/providers/firestore.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:jiffy/jiffy.dart';
-import 'package:url_launcher/url_launcher.dart';
 import 'package:flutter/gestures.dart';
-
 import '../extensions/string_validations.dart';
 import '../search/search_details.dart';
 
@@ -50,112 +48,6 @@ class ListItem extends ConsumerWidget {
                     ref.read(activeList.notifier).value = entityId;
                   },
                 ),
-                Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      Container(
-                          padding: EdgeInsets.all(8.0),
-                          child: Text.rich(TextSpan(
-                              style: TextStyle(
-                                  decoration: TextDecoration.underline),
-                              //make link underline
-                              text: "View source page",
-                              recognizer: TapGestureRecognizer()
-                                ..onTap = () async {
-                                  //on tap code here, you can navigate to other page or URL
-                                  final url = Uri.parse(
-                                      entityDoc.data()!['domainURL'] ?? '#');
-                                  var urllaunchable = await canLaunchUrl(
-                                      url); //canLaunch is from url_launcher package
-                                  if (urllaunchable) {
-                                    await launchUrl(
-                                        url); //launch is from url_launcher package to launch URL
-                                  } else {
-                                    print("URL can't be launched.");
-                                  }
-                                })))
-                    ]),
-                Row(
-                    mainAxisAlignment: MainAxisAlignment.start,
-                    children: <Widget>[
-                      Container(
-                          padding: EdgeInsets.all(8.0),
-                          child: Text.rich(TextSpan(
-                              style: TextStyle(
-                                  decoration: TextDecoration.underline),
-                              //make link underline
-                              text: "View source list",
-                              recognizer: TapGestureRecognizer()
-                                ..onTap = () async {
-                                  //on tap code here, you can navigate to other page or URL
-                                  final url = Uri.parse(
-                                      entityDoc.data()!['listURL'] ?? '#');
-                                  var urllaunchable = await canLaunchUrl(
-                                      url); //canLaunch is from url_launcher package
-                                  if (urllaunchable) {
-                                    await launchUrl(
-                                        url); //launch is from url_launcher package to launch URL
-                                  } else {
-                                    print("URL can't be launched.");
-                                  }
-                                })))
-                    ]),
-                InkWell(
-                    child: IconButton(
-                        icon: const Icon(Icons.edit),
-                        onPressed: () {
-                          showDialog(
-                              context: context,
-                              builder: (BuildContext context) {
-                                final _formKey = GlobalKey<FormState>();
-                                return AlertDialog(
-                                  scrollable: true,
-                                  title: Text('Sanction list entity fields'),
-                                  content: Padding(
-                                    padding: const EdgeInsets.all(8.0),
-                                    child: Form(
-                                      key: _formKey,
-                                      child: Column(
-                                        children: <Widget>[
-                                          DocFieldTextEdit(
-                                              FirebaseFirestore.instance
-                                                  .doc('list/${entityId}'),
-                                              'name',
-                                              decoration: InputDecoration(
-                                                  hintText: "Entity Name")),
-                                          DocFieldTextEdit(
-                                              FirebaseFirestore.instance
-                                                  .doc('list/${entityId}'),
-                                              'address',
-                                              decoration: InputDecoration(
-                                                  hintText: "Entity address")),
-                                          DocFieldTextEdit(
-                                              FirebaseFirestore.instance
-                                                  .doc('list/${entityId}'),
-                                              'dataSource',
-                                              decoration: InputDecoration(
-                                                  hintText: "Data Source")),
-                                          DocFieldTextEdit(
-                                              FirebaseFirestore.instance
-                                                  .doc('list/${entityId}'),
-                                              'website',
-                                              decoration: InputDecoration(
-                                                  hintText: "Website")),
-                                        ],
-                                      ),
-                                    ),
-                                  ),
-                                  actions: [
-                                    ElevatedButton(
-                                      onPressed: () {
-                                        Navigator.of(context).pop();
-                                      },
-                                      child: const Text('Done'),
-                                    )
-                                  ],
-                                );
-                              });
-                        })),
               ])));
   }
 


### PR DESCRIPTION
As per my assigned Kanban task "Move source and list URL widget to list details widget".

Currently these links widgets are nested inside Container widgets. This might need to be changed later for better responsiveness.