### PR TITLE
Can now press the enter key to search

### DIFF
--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -18,6 +18,20 @@ final selectedRef = StateNotifierProvider<
         GenericStateNotifier<DocumentReference?>, DocumentReference?>(
     (ref) => GenericStateNotifier<DocumentReference?>(null));
 
+void setSearchValue(searchCtrl) {
+  if (searchCtrl.text.isEmpty) return;
+  FirebaseFirestore.instance
+      .collection('user')
+      .doc(FirebaseAuth.instance.currentUser!.uid)
+      .collection('search')
+      .doc(searchCtrl.text)
+      .set({
+    'target': searchCtrl.text,
+    'timeCreated': FieldValue.serverTimestamp(),
+    'author': FirebaseAuth.instance.currentUser!.uid,
+  });
+}
+
 class SearchPage extends ConsumerWidget {
   final TextEditingController searchCtrl = TextEditingController();
 
@@ -50,20 +64,8 @@ class SearchPage extends ConsumerWidget {
                               child: TextField(
                             onChanged: (v) {},
                             controller: searchCtrl,
-                            onSubmitted: (value) {
-                              if (searchCtrl.text.isEmpty) return;
-                              FirebaseFirestore.instance
-                                  .collection('user')
-                                  .doc(FirebaseAuth.instance.currentUser!.uid)
-                                  .collection('search')
-                                  .doc(searchCtrl.text)
-                                  .set({
-                                'target': searchCtrl.text,
-                                'timeCreated': FieldValue.serverTimestamp(),
-                                'author':
-                                    FirebaseAuth.instance.currentUser!.uid,
-                              });
-                            },
+                            onSubmitted: (value) async =>
+                                setSearchValue(searchCtrl),
                           )),
                           ElevatedButton(
                               child: Text("Search"),
@@ -90,17 +92,7 @@ class SearchPage extends ConsumerWidget {
                                 //       .instance.currentUser!.uid,
                                 // });
 
-                                FirebaseFirestore.instance
-                                    .collection('user')
-                                    .doc(FirebaseAuth.instance.currentUser!.uid)
-                                    .collection('search')
-                                    .doc(searchCtrl.text)
-                                    .set({
-                                  'target': searchCtrl.text,
-                                  'timeCreated': FieldValue.serverTimestamp(),
-                                  'author':
-                                      FirebaseAuth.instance.currentUser!.uid,
-                                });
+                                setSearchValue(searchCtrl);
                               })
                         ],
                       ),

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -48,7 +48,23 @@ class SearchPage extends ConsumerWidget {
                         children: [
                           Expanded(
                               child: TextField(
-                                  onChanged: (v) {}, controller: searchCtrl)),
+                            onChanged: (v) {},
+                            controller: searchCtrl,
+                            onSubmitted: (value) {
+                              if (searchCtrl.text.isEmpty) return;
+                              FirebaseFirestore.instance
+                                  .collection('user')
+                                  .doc(FirebaseAuth.instance.currentUser!.uid)
+                                  .collection('search')
+                                  .doc(searchCtrl.text)
+                                  .set({
+                                'target': searchCtrl.text,
+                                'timeCreated': FieldValue.serverTimestamp(),
+                                'author':
+                                    FirebaseAuth.instance.currentUser!.uid,
+                              });
+                            },
+                          )),
                           ElevatedButton(
                               child: Text("Search"),
                               onPressed: () async {

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -18,24 +18,24 @@ final selectedRef = StateNotifierProvider<
         GenericStateNotifier<DocumentReference?>, DocumentReference?>(
     (ref) => GenericStateNotifier<DocumentReference?>(null));
 
-void setSearchValue(searchCtrl) {
-  if (searchCtrl.text.isEmpty) return;
-  FirebaseFirestore.instance
-      .collection('user')
-      .doc(FirebaseAuth.instance.currentUser!.uid)
-      .collection('search')
-      .doc(searchCtrl.text)
-      .set({
-    'target': searchCtrl.text,
-    'timeCreated': FieldValue.serverTimestamp(),
-    'author': FirebaseAuth.instance.currentUser!.uid,
-  });
-}
-
 class SearchPage extends ConsumerWidget {
   final TextEditingController searchCtrl = TextEditingController();
 
   final now = DateTime.now(); //
+
+  void setSearchValue() {
+    if (searchCtrl.text.isEmpty) return;
+    FirebaseFirestore.instance
+        .collection('user')
+        .doc(FirebaseAuth.instance.currentUser!.uid)
+        .collection('search')
+        .doc(searchCtrl.text)
+        .set({
+      'target': searchCtrl.text,
+      'timeCreated': FieldValue.serverTimestamp(),
+      'author': FirebaseAuth.instance.currentUser!.uid,
+    });
+  }
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {
@@ -64,8 +64,7 @@ class SearchPage extends ConsumerWidget {
                               child: TextField(
                             onChanged: (v) {},
                             controller: searchCtrl,
-                            onSubmitted: (value) async =>
-                                setSearchValue(searchCtrl),
+                            onSubmitted: (value) async => setSearchValue(),
                           )),
                           ElevatedButton(
                               child: Text("Search"),
@@ -92,7 +91,7 @@ class SearchPage extends ConsumerWidget {
                                 //       .instance.currentUser!.uid,
                                 // });
 
-                                setSearchValue(searchCtrl);
+                                setSearchValue();
                               })
                         ],
                       ),


### PR DESCRIPTION
For Kanban board task:
`Start search on 'Enter' key press`

Some duplicated code with the on mouse click on the Search button. Request changes if you'd prefer this to be in a separate function.