### PR TITLE
Sanctions list is now in alphabetical, case insensitive order based on the 'name' field value.

### DIFF
--- a/lib/lists/lists_list.dart
+++ b/lib/lists/lists_list.dart
@@ -58,6 +58,9 @@ class Lists extends ConsumerWidget {
                                   FirebaseAuth.instance.currentUser!.uid)
                               .toList()
                           : entities.docs)
+                        ..sort(((a, b) => (a.data()['name']?.toLowerCase() ??
+                                '')
+                            .compareTo(b.data()['name']?.toLowerCase() ?? '')))
                       // ..sort((a, b) => a[ref.watch(activeSort) ?? 'id']
                       //     .compareTo(b[ref.watch(activeSort) ?? 'id']))
                       )


### PR DESCRIPTION
**For Kanban name: "Sort "sanctions list" list alphabetically by name"**

However, those entries with the name "undefined list name" are not sorted as I believe that's been hardcoded elsewhere in the project code, so this is not a mistake of this pull request.

![image](https://user-images.githubusercontent.com/36615723/224601042-36bb73ac-060e-4d50-b35a-8073d355e135.png)
