### PR TITLE
Creates a whole new search document so that the target values can now be the same

### DIFF
--- a/lib/search/search_list.dart
+++ b/lib/search/search_list.dart
@@ -21,7 +21,10 @@ class SearchHistory extends ConsumerWidget {
       padding: EdgeInsets.zero,
       shrinkWrap: true,
       children: ref
-          .watch(colSP('user/${FirebaseAuth.instance.currentUser!.uid}/search'))
+          .watch(colSPfiltered(
+              'user/${FirebaseAuth.instance.currentUser!.uid}/search',
+              orderBy: 'timeCreated',
+              isOrderDesc: true))
           .when(
               loading: () => [Container()],
               error: (e, s) => [ErrorWidget(e)],

--- a/lib/search/search_list.dart
+++ b/lib/search/search_list.dart
@@ -43,9 +43,10 @@ class SearchHistory extends ConsumerWidget {
                 //     // print(sortedBy);
                 //     return a[sortedBy].compareTo(b[sortedBy]);
                 //   });
-                return data.docs
+
+                return (data.docs
                     .map((e) =>
                         SearchListItem(e.reference, _selectedItemNotifier))
-                    .toList();
+                    .toList());
               }));
 }

--- a/lib/search/search_list_item.dart
+++ b/lib/search/search_list_item.dart
@@ -22,9 +22,7 @@ class SearchListItem extends ConsumerWidget {
                 child: Column(
               children: [
                 ListTile(
-                  title: Text(searchDoc.id
-                      //(searchDoc.data()!['target'] ?? ''),
-                      ),
+                  title: Text(searchDoc.data()!['target'] ?? ''),
                   trailing: Text(searchDoc.data()!['resultsCount'].toString()),
                   // subtitle: Text(entityDoc.data()!['desc'] ?? 'desc'),
                   // trailing: Column(children: <Widget>[

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -42,8 +42,7 @@ class SearchPage extends ConsumerWidget {
         .collection('user')
         .doc(FirebaseAuth.instance.currentUser!.uid)
         .collection('search')
-        .doc(text)
-        .set({
+        .add({
       'target': text,
       'timeCreated': FieldValue.serverTimestamp(),
       'author': FirebaseAuth.instance.currentUser!.uid,


### PR DESCRIPTION
**For Kanban name: "Allow duplicate search request"**

Previously the search documents in Firestore were named by their search value (i.e. target), and I had to change this to a unique ID to allow duplicate documents of the same target.

![image](https://user-images.githubusercontent.com/36615723/224609586-3a811581-831e-4ee8-948c-9a7017620b1a.png)

All is working as far as I can tell.