### PR TITLE
Fixed BUG: When navigating between sanction lists entity details remains the same

### DIFF
--- a/lib/lists/list_item_tile.dart
+++ b/lib/lists/list_item_tile.dart
@@ -57,6 +57,7 @@ class _ListItemState extends ConsumerState<ListItemTile> {
 Last updated on ${Jiffy(entityDoc.data()!['lastUpdateTime'].toDate()).format(DISPLAY_DATE_TIME_FORMAT)}'''),
                   isThreeLine: true,
                   onTap: () {
+                    ref.read(selectedItem.notifier).value = null;
                     ref.read(selectedEntityList.notifier).value = null;
                     ref.read(selectedListItem.notifier).value = widget.entityId;
                     ref.read(widget.activeList.notifier).value =

--- a/lib/lists/lists_page.dart
+++ b/lib/lists/lists_page.dart
@@ -12,14 +12,14 @@ import 'jsonview_switch.dart';
 
 import 'indexing/indexing_item_list.dart';
 
+final selectedItem = StateNotifierProvider<
+        GenericStateNotifier<Map<String, dynamic>?>, Map<String, dynamic>?>(
+    (ref) => GenericStateNotifier<Map<String, dynamic>?>(null));
+
 class ListsPage extends ConsumerWidget {
   final activeList =
       StateNotifierProvider<GenericStateNotifier<String?>, String?>(
           (ref) => GenericStateNotifier<String?>(null));
-
-  final selectedItem = StateNotifierProvider<
-          GenericStateNotifier<Map<String, dynamic>?>, Map<String, dynamic>?>(
-      (ref) => GenericStateNotifier<Map<String, dynamic>?>(null));
 
   @override
   Widget build(BuildContext context, WidgetRef ref) {


### PR DESCRIPTION
**For Kanban task: "BUG: When navigating between sanction lists entity details remains the same"**

When navigating between sanction lists (1st/left column), the entity details (3rd/right column) is cleared out.