### PR TITLE
Fixed BUG: 'View source page' and 'View source list' link is not working

### DIFF
--- a/lib/lists/list_details.dart
+++ b/lib/lists/list_details.dart
@@ -108,8 +108,7 @@ class ListDetails extends ConsumerWidget {
                 recognizer: TapGestureRecognizer()
                   ..onTap = () async {
                     //on tap code here, you can navigate to other page or URL
-                    final url =
-                        Uri.parse(entityDoc.data()!['domainURL'] ?? '#');
+                    final url = Uri.parse(entityDoc.data()!['website'] ?? '#');
                     var urllaunchable = await canLaunchUrl(
                         url); //canLaunch is from url_launcher package
                     if (urllaunchable) {
@@ -130,7 +129,8 @@ class ListDetails extends ConsumerWidget {
                 recognizer: TapGestureRecognizer()
                   ..onTap = () async {
                     //on tap code here, you can navigate to other page or URL
-                    final url = Uri.parse(entityDoc.data()!['listURL'] ?? '#');
+                    final url =
+                        Uri.parse(entityDoc.data()!['dataSource'] ?? '#');
                     var urllaunchable = await canLaunchUrl(
                         url); //canLaunch is from url_launcher package
                     if (urllaunchable) {


### PR DESCRIPTION
Fix: The two URLs, set by admins as per the below screenshot, were being referenced by different names on the URL Launcher links 
![image](https://user-images.githubusercontent.com/36615723/231016831-49665123-732b-47e8-aa91-89adbfa5d126.png)
Note that all URLs must begin with 'http' or 'https' for URL Launcher to work