### PR TITLE
Rename List page to Sanctions page

### DIFF
--- a/lib/side_nav_bar.dart
+++ b/lib/side_nav_bar.dart
@@ -16,7 +16,7 @@ class CustomNavRail extends ConsumerWidget {
     ),
     'lists': const NavigationRailDestination(
       icon: Icon(Icons.source),
-      label: Text('Lists'),
+      label: Text('Sanctions'),
     ),
     'cases': const NavigationRailDestination(
       icon: Icon(Icons.assignment_late),


### PR DESCRIPTION
I have changed;
List page name to Sanctions page.
Here is the screenshot.

<img width="1203" alt="Screenshot 2023-04-24 at 2 58 42 pm" src="https://user-images.githubusercontent.com/122496030/233903791-87914a93-04dc-42d6-9e52-4fdfe8bac6df.png">
