### PR TITLE
Fixed bug search results include 'undefined' if name fields are empty

### DIFF
--- a/lib/search/search_results.dart
+++ b/lib/search/search_results.dart
@@ -48,7 +48,8 @@ class SearchResults extends ConsumerWidget {
                           res.data()['ref'];
                     },
                     child: ListTile(
-                        title: Text("Name: " + res.data()['target']),
+                        title: Text("Name: " +
+                            res.data()['target'].replaceAll(" undefined", "")),
                         subtitle: Column(
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [


### PR DESCRIPTION
ORIGINAL:
![image](https://github.com/amlcloud/screensite/assets/36615723/f409ac5c-cc53-4c51-83bd-e9fb9be3cecd)

Note that this will cause issues if any part of a person's actual name in the very unlikely chance begins with the word 'undefined'