### PR TITLE
Added match score to search result item

### DIFF
--- a/lib/lists/jsonview_switch.dart
+++ b/lib/lists/jsonview_switch.dart
@@ -20,11 +20,16 @@ class SwitchJSON extends ConsumerWidget {
     final isSwitched = ref.watch(SwitchJsonStateProvider);
     return Column(
       children: [
+        Container(
+            child: (isSwitched == false)
+                ? CustomJsonViewer(selectedItem)
+                // Widget with prittier data should go here, so its a placeholder for now
+                : JsonViewer(selectedItem)),
         Row(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             Text(
-              'JSON data',
+              'View Raw Data',
               style: TextStyle(color: Colors.black),
             ),
             Switch(
@@ -35,11 +40,7 @@ class SwitchJSON extends ConsumerWidget {
             )
           ],
         ),
-        Container(
-            child: (isSwitched == false)
-                ? CustomJsonViewer(selectedItem)
-                // Widget with prittier data should go here, so its a placeholder for now
-                : JsonViewer(selectedItem)),
+        
       ],
     );
   }

--- a/lib/search/search_list_item.dart
+++ b/lib/search/search_list_item.dart
@@ -35,7 +35,7 @@ class SearchListItem extends ConsumerWidget {
                   //   //     Icon(Icons.delete))
                   // ]),
                   onTap: () {
-                    ref.read(selectedSearchResult.notifier).value =
+                    ref.read(selectedSearchId.notifier).value =
                         searchRef.id;
                     ref.read(_selectedItemNotifier.notifier).value = null;
                   },

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -1,23 +1,29 @@
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:common/common.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:providers/generic.dart';
 import 'package:screensite/app_bar.dart';
-import 'package:screensite/common.dart';
+
 import 'package:screensite/search/search_details.dart';
 import 'package:screensite/search/search_list.dart';
 import 'package:screensite/search/search_results_item.dart';
 import 'package:screensite/drawer.dart';
 import 'package:screensite/side_nav_bar.dart';
+import 'package:widgets/doc_print.dart';
 
-final selectedSearchResult =
+final selectedSearchId =
     StateNotifierProvider<GenericStateNotifier<String?>, String?>(
         (ref) => GenericStateNotifier<String?>(null));
 
-final selectedRef = StateNotifierProvider<
-        GenericStateNotifier<DocumentReference?>, DocumentReference?>(
-    (ref) => GenericStateNotifier<DocumentReference?>(null));
+final selectedSearchResultId =
+    StateNotifierProvider<GenericStateNotifier<String?>, String?>(
+        (ref) => GenericStateNotifier<String?>(null));
+
+final _searchResultsSancDocRef =
+    StateNotifierProvider<GenericStateNotifier<DR?>, DR?>(
+        (ref) => GenericStateNotifier<DR?>(null));
 
 const MINIMUM_SEARCH_LENGTH = 5;
 
@@ -209,19 +215,21 @@ class SearchPage extends ConsumerWidget {
                                                   "Matches",
                                                   style: Theme.of(context).textTheme.titleLarge,
                                                 )),
-                                            ref.watch(selectedSearchResult) == null
+                                          ref.watch(selectedSearchId) == null
                                                 ? Container(height: double.maxFinite,)
                                                 : Padding(
                                                     padding: EdgeInsets.all(8),
                                                     child: SingleChildScrollView(
                                                       child: SearchDetails(
                                                           FirebaseFirestore.instance.doc(
-                                                            'search/${ref.watch(selectedSearchResult)}',
+                                                          'search/${ref.watch(selectedSearchId)}',
                                                           ),
-                                                          selectedRef),
+                                                        _searchResultsSancDocRef),
                                                     )),
+                                                
                                           ],
                                         ),
+                                        
                                       ),
                                     
                                   )),
@@ -245,12 +253,17 @@ class SearchPage extends ConsumerWidget {
                                                   Padding(
                                                       padding: EdgeInsets.all(10),
                                                       child: ref.watch(
-                                                                  selectedRef) ==
+                                                                  _searchResultsSancDocRef) ==
                                                               null
                                                           ? Container()
                                                           : SearchResultsItem(
                                                               ref.watch(
-                                                                  selectedRef)!))
+                                                                  _searchResultsSancDocRef)!,
+                                                              FirebaseFirestore
+                                                                  .instance
+                                                                  .doc(
+                                                                'user/${FirebaseAuth.instance.currentUser!.uid}/search/${ref.watch(selectedSearchId)}/res/${ref.watch(selectedSearchResultId)}',
+                                                              )))
                                                 ],
                                               ),
                                             ))
@@ -279,7 +292,7 @@ class SearchPage extends ConsumerWidget {
                               ),
                             ),
                           ),
-                          SearchHistory(selectedRef),
+                          SearchHistory(_searchResultsSancDocRef),
                         ],
                       ),
                     ),

--- a/lib/search/search_results.dart
+++ b/lib/search/search_results.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import 'package:providers/firestore.dart';
 import 'package:providers/generic.dart';
+import 'package:screensite/search/search_page.dart';
 import 'package:widgets/doc_field_text.dart';
 
 class SearchResults extends ConsumerWidget {
@@ -54,6 +55,7 @@ class SearchResults extends ConsumerWidget {
                     onTap: () {
                       ref.read(_selectedItemNotifier.notifier).value =
                           res.data()['ref'];
+                      ref.read(selectedSearchResultId.notifier).value = res.id;
                     },
                     child: ListTile(
                         title: Text("Name: " + res.data()['target']),
@@ -61,7 +63,7 @@ class SearchResults extends ConsumerWidget {
                           crossAxisAlignment: CrossAxisAlignment.start,
                           children: [
                             Text(
-                                "Match score: ${matchScore.toStringAsFixed(2)} %"),
+                                "Match score: ${matchScore.toStringAsFixed(0)} %"),
                             Text("Levscore: " +
                                 res.data()['levScore'].toString()),
                             Text("List id: " +

--- a/lib/search/search_results_item.dart
+++ b/lib/search/search_results_item.dart
@@ -1,17 +1,31 @@
+import 'dart:math';
+
 import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:common/common.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
+import 'package:providers/firestore.dart';
 import 'package:screensite/lists/jsonview_switch.dart';
+import 'package:firebase_auth/firebase_auth.dart';
+import 'package:screensite/search/search_page.dart';
+import 'package:widgets/doc_field_text.dart';
+import 'package:common/firestore.dart';
+import 'package:widgets/doc_print.dart';
+import 'package:widgets/doc_stream_widget.dart';
 
 class SearchResultsItem extends ConsumerWidget {
-  final DocumentReference _documentReference;
+  final DR _searchResultsSancDocRef;
+  final DR _searchResultDocRef;
 
-  const SearchResultsItem(this._documentReference);
-
+  const SearchResultsItem(
+    this._searchResultsSancDocRef,
+    this._searchResultDocRef,
+  );
+// Refactor entire code
   @override
   Widget build(BuildContext context, WidgetRef ref) {
     return StreamBuilder(
-        stream: _documentReference.get().asStream(),
+        stream: _searchResultsSancDocRef.get().asStream(),
         builder: (context, snapshot) {
           Widget widget;
           if (snapshot.data == null) {
@@ -19,7 +33,56 @@ class SearchResultsItem extends ConsumerWidget {
           } else {
             DocumentSnapshot<Map<String, dynamic>> documentSnapshot =
                 snapshot.data as DocumentSnapshot<Map<String, dynamic>>;
-            widget = SwitchJSON(documentSnapshot.data());
+
+            widget = Container(
+                padding: EdgeInsets.all(10),
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Row(
+                      mainAxisAlignment: MainAxisAlignment.spaceBetween,
+                      children: [
+                        Text(
+                          "List ID: " +
+                              _searchResultsSancDocRef.parent.parent!.id
+                                  .toString(),
+                          style: Theme.of(context).textTheme.titleSmall,
+                        ),
+
+                        // Error: Expected a value of type 'AutoDisposeStreamProvider<DocumentSnapshot<Map<String, dynamic>>>', but
+                        //          got one of type '_JsonDocumentReference'
+                        DocStreamWidget(docSP(_searchResultDocRef.path),
+                            ((context, doc) {
+                          num matchScore = (1 -
+                                  doc.data()!['levScore'] /
+                                      doc.data()!['target'].length) *
+                              100;
+                          return Text(
+                              'Match Score: ${matchScore.toStringAsFixed(0)} %');
+                        }))
+                      ],
+                    ),
+                    Container(
+                      margin: EdgeInsets.fromLTRB(0, 10, 0, 10),
+                      child: Row(
+                        children: [
+                          Text(
+                            "List Name: ",
+                            style: Theme.of(context).textTheme.titleSmall,
+                          ),
+                          DocFieldText(
+                              _searchResultsSancDocRef.parent.parent!, 'name',
+                              style: Theme.of(context).textTheme.titleSmall),
+                        ],
+                      ),
+                    ),
+                    Container(
+                        padding: EdgeInsets.fromLTRB(16, 24, 16, 24),
+                        decoration: BoxDecoration(
+                            color: Theme.of(context).colorScheme.background),
+                        child: SwitchJSON(documentSnapshot.data()))
+                  ],
+                ));
           }
           return widget;
         });


### PR DESCRIPTION
# Added match score to Search Item Result widget. 

### Changes made to files: 

## search_page.dart

1. Added GenericStateNotifier named `selectedSearchResultId`
2. Added parameter to the constructor for `searchResultItem` widget.

## search_result.dart

1. Added `id` of the search document to the notifier `selectedSearchResultId`
2. Removed and rounded decimal values from Match Score 


## jsonview_switch.dart

1. Changed the text `JSON Data` to `View Raw Data`
2. Changed the position of the `Switch Widget` to the bottom of the container.

## search_result_item.dart

1. Added List ID, List Name, and Match Score to the Widget
2. Added some styling to the Widget

## search_list_item.dart

1. Renamed document reference


# UI Preview
![Screenshot (18)](https://github.com/amlcloud/screensite/assets/98571452/5854a949-39e9-4b23-8d6b-d82f107036bf)
