### PR TITLE
Fixed Missed variable during renaming

### DIFF
--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -59,7 +59,7 @@ class SearchPage extends ConsumerWidget {
         'timeCreated': FieldValue.serverTimestamp(),
         'author': FirebaseAuth.instance.currentUser!.uid,
       });
-      ref.read(selectedSearchResult.notifier).value = newSearchDocRef.id;
+      ref.read(selectedSearchResultId.notifier).value = newSearchDocRef.id;
       searchCtrl.clear();
     }
 


### PR DESCRIPTION
# Changes made to files

## search_page.dart

1. Renamed `selectedSearchResult` to `selectedSearchResultId`

