### PR TITLE
Improve UI: Make Matches Header Static and Content Scrollable

### DIFF
--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -193,7 +193,7 @@ class SearchPage extends ConsumerWidget {
                                 
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
-                                 // Matches section
+                                  // Matches section
                                   Expanded(
                                     child: Card(
                                       child: Column(
@@ -233,41 +233,6 @@ class SearchPage extends ConsumerWidget {
                                       ),
                                     ),
                                   ),
-
-                                  
-
-                                  // Expanded(
-                                  //   child: Card(
-                                  //     child: SingleChildScrollView(
-                                  //       child: Column(
-                                          
-                                  //         mainAxisSize: MainAxisSize.max,
-                                  //         crossAxisAlignment: CrossAxisAlignment.start,
-                                          
-                                  //         children: [
-                                  //           Container(
-                                                
-                                  //               padding: EdgeInsets.all(16.0),
-                                  //               child: Text(
-                                  //                 "Matches",
-                                  //                 style: Theme.of(context).textTheme.titleLarge,
-                                  //               )),
-                                  //           ref.watch(selectedSearchResult) == null
-                                  //               ? Container(height: double.maxFinite,)
-                                  //               : Padding(
-                                  //                   padding: EdgeInsets.all(8),
-                                  //                   child: SingleChildScrollView(
-                                  //                     child: SearchDetails(
-                                  //                         FirebaseFirestore.instance.doc(
-                                  //                           'search/${ref.watch(selectedSearchResult)}',
-                                  //                         ),
-                                  //                         selectedRef),
-                                  //                   )),
-                                  //         ],
-                                  //       ),
-                                  //     ),
-                                    
-                                  // )),
                                   Expanded(
                                       child: Card(
                                           child: Column(
@@ -309,23 +274,21 @@ class SearchPage extends ConsumerWidget {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(
                           horizontal: 40.0, vertical: 20.0),
-                      child: SingleChildScrollView(
-                        child: Column(
-                          crossAxisAlignment: CrossAxisAlignment.start,
-                          children: [
-                            Container(
-                              child: Padding(
-                                padding: const EdgeInsets.all(16.0),
-                                child: Text(
-                                  "Search History",
-                                  style:
-                                      Theme.of(context).textTheme.titleLarge,
-                                ),
+                      child: Column(
+                        crossAxisAlignment: CrossAxisAlignment.start,
+                        children: [
+                          Container(
+                            child: Padding(
+                              padding: const EdgeInsets.all(16.0),
+                              child: Text(
+                                "Search History",
+                                style:
+                                    Theme.of(context).textTheme.titleLarge,
                               ),
                             ),
-                            SearchHistory(selectedRef),
-                          ],
-                        ),
+                          ),
+                          SearchHistory(selectedRef),
+                        ],
                       ),
                     ),
                   ),

--- a/lib/search/search_page.dart
+++ b/lib/search/search_page.dart
@@ -193,38 +193,81 @@ class SearchPage extends ConsumerWidget {
                                 
                                 crossAxisAlignment: CrossAxisAlignment.start,
                                 children: [
+                                 // Matches section
                                   Expanded(
                                     child: Card(
-                                      child: SingleChildScrollView(
-                                        child: Column(
-                                          
-                                          mainAxisSize: MainAxisSize.max,
-                                          crossAxisAlignment: CrossAxisAlignment.start,
-                                          
-                                          children: [
-                                            Container(
-                                                
-                                                padding: EdgeInsets.all(16.0),
-                                                child: Text(
-                                                  "Matches",
-                                                  style: Theme.of(context).textTheme.titleLarge,
-                                                )),
-                                            ref.watch(selectedSearchResult) == null
-                                                ? Container(height: double.maxFinite,)
-                                                : Padding(
-                                                    padding: EdgeInsets.all(8),
-                                                    child: SingleChildScrollView(
+                                      child: Column(
+                                        crossAxisAlignment:
+                                            CrossAxisAlignment.start,
+                                        children: [
+                                          Container(
+                                              padding: EdgeInsets.all(16.0),
+                                              child: Text(
+                                                "Matches",
+                                                style: Theme.of(context)
+                                                    .textTheme
+                                                    .titleLarge,
+                                              )),
+                                          Expanded(
+                                            child: ref.watch(
+                                                        selectedSearchResult) ==
+                                                    null
+                                                ? Container(
+                                                    height: double.maxFinite)
+                                                : SingleChildScrollView(
+                                                    child: Padding(
+                                                      padding:
+                                                          EdgeInsets.all(8),
                                                       child: SearchDetails(
-                                                          FirebaseFirestore.instance.doc(
-                                                            'search/${ref.watch(selectedSearchResult)}',
-                                                          ),
-                                                          selectedRef),
-                                                    )),
-                                          ],
-                                        ),
+                                                        FirebaseFirestore
+                                                            .instance
+                                                            .doc(
+                                                          'search/${ref.watch(selectedSearchResult)}',
+                                                        ),
+                                                        selectedRef,
+                                                      ),
+                                                    ),
+                                                  ),
+                                          ),
+                                        ],
                                       ),
+                                    ),
+                                  ),
+
+                                  
+
+                                  // Expanded(
+                                  //   child: Card(
+                                  //     child: SingleChildScrollView(
+                                  //       child: Column(
+                                          
+                                  //         mainAxisSize: MainAxisSize.max,
+                                  //         crossAxisAlignment: CrossAxisAlignment.start,
+                                          
+                                  //         children: [
+                                  //           Container(
+                                                
+                                  //               padding: EdgeInsets.all(16.0),
+                                  //               child: Text(
+                                  //                 "Matches",
+                                  //                 style: Theme.of(context).textTheme.titleLarge,
+                                  //               )),
+                                  //           ref.watch(selectedSearchResult) == null
+                                  //               ? Container(height: double.maxFinite,)
+                                  //               : Padding(
+                                  //                   padding: EdgeInsets.all(8),
+                                  //                   child: SingleChildScrollView(
+                                  //                     child: SearchDetails(
+                                  //                         FirebaseFirestore.instance.doc(
+                                  //                           'search/${ref.watch(selectedSearchResult)}',
+                                  //                         ),
+                                  //                         selectedRef),
+                                  //                   )),
+                                  //         ],
+                                  //       ),
+                                  //     ),
                                     
-                                  )),
+                                  // )),
                                   Expanded(
                                       child: Card(
                                           child: Column(
@@ -266,21 +309,23 @@ class SearchPage extends ConsumerWidget {
                     child: Padding(
                       padding: const EdgeInsets.symmetric(
                           horizontal: 40.0, vertical: 20.0),
-                      child: Column(
-                        crossAxisAlignment: CrossAxisAlignment.start,
-                        children: [
-                          Container(
-                            child: Padding(
-                              padding: const EdgeInsets.all(16.0),
-                              child: Text(
-                                "Search History",
-                                style:
-                                    Theme.of(context).textTheme.titleLarge,
+                      child: SingleChildScrollView(
+                        child: Column(
+                          crossAxisAlignment: CrossAxisAlignment.start,
+                          children: [
+                            Container(
+                              child: Padding(
+                                padding: const EdgeInsets.all(16.0),
+                                child: Text(
+                                  "Search History",
+                                  style:
+                                      Theme.of(context).textTheme.titleLarge,
+                                ),
                               ),
                             ),
-                          ),
-                          SearchHistory(selectedRef),
-                        ],
+                            SearchHistory(selectedRef),
+                          ],
+                        ),
                       ),
                     ),
                   ),


### PR DESCRIPTION
Changes include:
- Wrapping the `SearchDetails` widget with a `SingleChildScrollView` to make it scrollable.
- Keeping the "Matches" header outside the `SingleChildScrollView` to ensure it stays static.
- Refactoring layout widgets for better readability and maintenance.

This change improves the usability of the Matches section by keeping the context (header) visible while a user scrolls through the search results.